### PR TITLE
fix(validation): accept null for optional union types.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,5 +8,6 @@ those changes to CLEARTYPE SRL.
 
 | Username | Name |
 | :------- | :--- |
+| [@edwardgeorge](https://github.com/edwardgeorge) | Edward George |
 | [@gaqzi](https://github.com/gaqzi) | Björn Andersson |
 | [@joranbeasley](https://github.com/joranbeasley) | |

--- a/molten/typing.py
+++ b/molten/typing.py
@@ -75,16 +75,14 @@ def extract_optional_annotation(annotation: Any) -> Tuple[bool, Any]:
     """Returns a tuple denoting whether or not the annotation is an
     Optional type and the inner annotation.
     """
-    if is_optional_annotation(annotation):
-        return True, annotation.__args__[0]
+    if typing_inspect.is_union_type(annotation):
+        args = get_args(annotation)
+        # filter arguments for NoneType
+        inner = tuple(
+            arg for arg in args
+            if not isinstance(arg, type) or not issubclass(arg, type(None)))
+        if len(inner) < len(args):
+            # if filtered list is less than original
+            # then we have an optional annotation.
+            return True, Union[inner]
     return False, annotation
-
-
-def is_optional_annotation(annotation: Any) -> bool:
-    """Returns True if the given annotation represents an Optional type.
-    """
-    try:
-        return getattr(annotation, "__origin__", None) is Union and \
-            issubclass(annotation.__args__[1], type(None))
-    except TypeError:  # pragma: no cover
-        return False

--- a/tests/validation/test_fields.py
+++ b/tests/validation/test_fields.py
@@ -1,3 +1,5 @@
+from typing import Optional, Union
+
 import pytest
 
 from molten import Field, FieldValidationError
@@ -40,3 +42,20 @@ def test_fields_can_fail_to_coerce_values():
         field.validate("invalid")
 
     assert e_data.value.message == "value could not be coerced to int"
+
+
+@pytest.mark.parametrize("annotation,value,expected", [
+    (Optional[Union[int, str]], None, None),
+    (Optional[Union[int, str]], 1, 1),
+    (Optional[Union[int, str]], "a", "a"),
+    (Union[Optional[int], str], None, None),
+    (Union[Optional[int], str], 1, 1),
+    (Union[Optional[int], str], "a", "a"),
+    (Union[int, Optional[str]], None, None),
+    (Union[int, Optional[str]], 1, 1),
+    (Union[int, Optional[str]], "a", "a"),
+])
+def test_fields_with_optional_unions(annotation, value, expected):
+    field = Field(annotation=annotation)
+    field.select_validator()
+    assert field.validate(value) == expected


### PR DESCRIPTION
Validating a field that is an optional union will fail when the value is null:

```
>>> field = Field(annotation=Optional[Union[int,str]])
>>> field.select_validator()
>>> field.validate(None)
---------------------------------------------------------------------------

molten/validation/field.py in validate(self, value)
    181         if value is None:
    182             if not is_optional:
--> 183                 raise FieldValidationError("this field cannot be null")
    184
    185             return value

FieldValidationError: this field cannot be null
```

The cause of this is that when determining if a field is optional in
`is_optional_annotation` the simply checks the second argument of the Union.

This works when the annotation is `Optional[X]` which expands to
`Union[X, NoneType]` but not, for instance, with `Optional[Union[X, Y]]` which
expands to `Union[X, Y, NoneType]`.

We could check the _last_ argument to `Union` but that would still fail on the,
slightly more contrived, example of `Union[Optional[X], Y]` which expands to
`Union[X, NoneType, Y]` and for which `null` would be perfectly valid.

Therefore, in this implementation, `is_optional_annotation` is dropped as
that involves iterating over the arguments to determine if one is `NoneType`
and we also need to iterate over the arguments in `extract_optional_annotation`
to produce the "inner annotation" so I do both in the same place now instead.
`is_optional_annotation` is not referenced anywhere else in the project, but
as this affects what is possibly the external API this is possibly a breaking
change.

Adds tests for the examples in `test_fields.py`.

BREAKING CHANGE: removes `is_optional_annotation` from `molten.typing`