### PR TITLE
openapi: support required fields read/writeOnly

### DIFF
--- a/molten/openapi/documents.py
+++ b/molten/openapi/documents.py
@@ -371,9 +371,13 @@ def _generate_field_schema(field_name: str, field: Field, schemas: Dict[str, Sch
 
         elif field.response_only:
             field_schema.read_only = True
+            if is_optional:
+                is_optional = not field.required
 
         elif field.request_only:
             field_schema.write_only = True
+            if is_optional:
+                is_optional = not field.required
 
         for option, value in field.validator_options.items():
             if option in Schema._FIELDS:

--- a/molten/validation/field.py
+++ b/molten/validation/field.py
@@ -87,6 +87,7 @@ class Field(Generic[_T]):
         responses.  Defaults to False.
       response_only: Whether or not to ignore this field when loading
         requests.  Defaults to False.
+      required: Whether this field is required. Defaults to False.
       allow_coerce: Whether or not values passed to this field may be
         coerced to the correct type.  Defaults to False.
       validator: The validator to use when loading data.  The schema
@@ -106,6 +107,7 @@ class Field(Generic[_T]):
         "response_name",
         "request_only",
         "response_only",
+        "required",
         "allow_coerce",
         "validator",
         "validator_options",
@@ -122,6 +124,7 @@ class Field(Generic[_T]):
             response_name: Optional[str] = None,
             request_only: bool = False,
             response_only: bool = False,
+            required: bool = False,
             allow_coerce: bool = False,
             validator: Optional[Validator[_T]] = None,
             **validator_options: Any,
@@ -135,6 +138,7 @@ class Field(Generic[_T]):
         self.response_name = response_name or name
         self.request_only = request_only
         self.response_only = response_only
+        self.required = required
         self.allow_coerce = allow_coerce
         self.validator = validator
         self.validator_options = validator_options

--- a/tests/openapi/fixtures/complex.json
+++ b/tests/openapi/fixtures/complex.json
@@ -369,6 +369,7 @@
       "tests.openapi.test_openapi.Category": {
         "type": "object",
         "required": [
+          "id",
           "name"
         ],
         "properties": {

--- a/tests/openapi/test_openapi.py
+++ b/tests/openapi/test_openapi.py
@@ -16,7 +16,7 @@ from molten.openapi import (
 
 @schema
 class Category:
-    id: Optional[int] = field(response_only=True)
+    id: Optional[int] = field(response_only=True, required=True)
     name: str
 
 

--- a/tests/validation/test_fields.py
+++ b/tests/validation/test_fields.py
@@ -21,7 +21,7 @@ def test_fields_are_representable():
 
     # When I call repr on it
     # Then I should get back its string representation
-    assert repr(field) == "Field(name='example', annotation=<class 'int'>, description=None, default=Missing, default_factory=None, request_name='example', response_name='example', request_only=False, response_only=False, allow_coerce=False, validator=None, validator_options={})"  # noqa
+    assert repr(field) == "Field(name='example', annotation=<class 'int'>, description=None, default=Missing, default_factory=None, request_name='example', response_name='example', request_only=False, response_only=False, required=False, allow_coerce=False, validator=None, validator_options={})"  # noqa
 
 
 @pytest.mark.parametrize("field,value,expected", [


### PR DESCRIPTION
The OpenAPI spec 3.0.0 specifies the following for read/writeOnly
schema properties :

    readOnly: If the property is marked as readOnly being true and is in
    the required list, the required will take effect on the response
    only.

This justifies adding a `required` argument on `Field`. Indeed this may
be useful to API clients to know that the field will always be present
in the response even if in python its type is Optional due to reuse of
the schema for request and response.