### PR TITLE
better parsing of  docstrings

### DIFF
--- a/molten/openapi/documents.py
+++ b/molten/openapi/documents.py
@@ -423,7 +423,7 @@ def _get_annotation(handler: Callable[..., Any], name: str, default: Any = None)
     return getattr(handler, f"openapi_{name}", default)
 
 
-def _parse_docstring(docstring) -> Dict[str, str]:
+def _parse_docstring(docstring: str) -> Dict[str, str]:
     """
     parse a docstring and return both a summary and description
     ... maybe at some point parse additional parameter info as well

--- a/molten/openapi/documents.py
+++ b/molten/openapi/documents.py
@@ -422,12 +422,13 @@ def _make_schema_ref(name: str) -> Dict[str, str]:
 def _get_annotation(handler: Callable[..., Any], name: str, default: Any = None) -> Any:
     return getattr(handler, f"openapi_{name}", default)
 
+
 def _parse_docstring(docstring):
     """
     parse a docstring and return both a summary and description
     ... maybe at some point parse additional parameter info as well
 
-    >>> _parse_docstring("a short docstring") == {'description':'','summary':'a short docstring'}
+    >>> _parse_docstring("a short docstring") == {'description': '','summary':'a short docstring'}
     True
     >>> _parse_docstring('a summary\\n\\n\\nand a description') == {'description':'and a description','summary':'a summary'}
     True
@@ -437,7 +438,7 @@ def _parse_docstring(docstring):
     :return: a dictionary with 2 keys 'description' and 'summary' guaranteed to be strings
     """
     #: split off any argument definitions from the docstring
-    docstring = re.split('[:@](?:param|return|type)[^:]*?\:', docstring, 1)[0]
+    docstring = re.split('[:@](?:param|return|type)[^:]*?:', docstring, 1)[0]
     summary = ""
     parts = docstring.split("\n\n", 1)
     if len(parts) == 1:
@@ -456,7 +457,7 @@ def _parse_docstring(docstring):
         else:  #: too long for a summary
             docstring = docstring
             summary = ""
-    return {'description':docstring,'summary':summary}
+    return {'description': docstring, 'summary': summary}
 
 
 def _sort_dict(data: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/molten/openapi/documents.py
+++ b/molten/openapi/documents.py
@@ -457,7 +457,7 @@ def _parse_docstring(docstring) -> Dict[str, str]:
         else:  #: too long for a summary
             docstring = docstring
             summary = ""
-    return {'description': docstring, 'summary': summary}
+    return {'description': docstring.strip(), 'summary': summary.strip()}
 
 
 def _sort_dict(data: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/molten/openapi/documents.py
+++ b/molten/openapi/documents.py
@@ -423,7 +423,7 @@ def _get_annotation(handler: Callable[..., Any], name: str, default: Any = None)
     return getattr(handler, f"openapi_{name}", default)
 
 
-def _parse_docstring(docstring):
+def _parse_docstring(docstring)->Dict[str,str]:
     """
     parse a docstring and return both a summary and description
     ... maybe at some point parse additional parameter info as well

--- a/molten/openapi/documents.py
+++ b/molten/openapi/documents.py
@@ -423,7 +423,7 @@ def _get_annotation(handler: Callable[..., Any], name: str, default: Any = None)
     return getattr(handler, f"openapi_{name}", default)
 
 
-def _parse_docstring(docstring)->Dict[str,str]:
+def _parse_docstring(docstring) -> Dict[str, str]:
     """
     parse a docstring and return both a summary and description
     ... maybe at some point parse additional parameter info as well

--- a/tests/openapi/fixtures/complex.json
+++ b/tests/openapi/fixtures/complex.json
@@ -52,6 +52,7 @@
         ],
         "operationId": "add_pet_deprecated",
         "description": "",
+        "summary": "",
         "parameters": [
           {
             "name": "accept",
@@ -107,7 +108,8 @@
           "pets"
         ],
         "operationId": "add_pet",
-        "description": "Add a new pet to the store.",
+        "summary": "Add a new pet to the store.",
+        "description": "",
         "parameters": [],
         "deprecated": false,
         "responses": {
@@ -153,6 +155,7 @@
         ],
         "operationId": "list_pets",
         "description": "",
+        "summary": "",
         "parameters": [],
         "deprecated": false,
         "responses": {
@@ -183,7 +186,8 @@
           "pets"
         ],
         "operationId": "update_pet",
-        "description": "Update an existing pet.",
+        "summary": "Update an existing pet.",
+        "description": "",
         "parameters": [
           {
             "name": "pet_id",
@@ -243,7 +247,8 @@
           "pets"
         ],
         "operationId": "delete_pet",
-        "description": "Delete an existing pet.",
+        "summary": "Delete an existing pet.",
+        "description": "",
         "parameters": [
           {
             "name": "pet_id",
@@ -279,7 +284,8 @@
           "pets"
         ],
         "operationId": "add_photo",
-        "description": "Add a photo to a pet.",
+        "summary": "Add a photo to a pet.",
+        "description": "",
         "parameters": [
           {
             "name": "pet_id",
@@ -323,6 +329,7 @@
         ],
         "operationId": "update_settings",
         "description": "",
+        "summary": "",
         "parameters": [],
         "deprecated": false,
         "responses": {

--- a/tests/openapi/fixtures/complex.json
+++ b/tests/openapi/fixtures/complex.json
@@ -10,7 +10,8 @@
       "get": {
         "tags": [],
         "operationId": "OpenAPIUIHandler",
-        "description": "Renders the Swagger UI.",
+        "summary": "Renders the Swagger UI.",
+        "description": "",
         "parameters": [],
         "deprecated": false,
         "responses": {
@@ -29,7 +30,8 @@
       "get": {
         "tags": [],
         "operationId": "schema",
-        "description": "Generates an OpenAPI v3 document.",
+        "description": "",
+        "summary": "Generates an OpenAPI v3 document.",
         "parameters": [],
         "deprecated": false,
         "responses": {

--- a/tests/openapi/test_openapi.py
+++ b/tests/openapi/test_openapi.py
@@ -188,7 +188,8 @@ def test_empty_app_can_return_openapi_document():
                 "get": {
                     "tags": [],
                     "operationId": "schema",
-                    "description": "Generates an OpenAPI v3 document.",
+                    "summary": "Generates an OpenAPI v3 document.",
+                    "description": "",
                     "deprecated": False,
                     "parameters": [],
                     "responses": {


### PR DESCRIPTION
I was frusterated by my IDE, which attempts to helpfully provide sphinx parameter definitions in any docstrings,  which caused the openapi spec docs to look funny.   i have been using a version with these changes for a while, and decided they might be useful to others

Im not sure if this is the appropriate place but this (or if it belongs more on annotation or something?)

ignores parameter specifications in docstrings

attempts to split the docstring into both a summary as well as a description.

I also would like to propose allowing `example` as an argument to  `field()` (not in this merge request)
as it is a valid openapi specification for parameters

